### PR TITLE
seperate relationships from graph edges

### DIFF
--- a/app/tree/components/MemberModal.tsx
+++ b/app/tree/components/MemberModal.tsx
@@ -401,6 +401,7 @@ export function ParentModal({
           Add {parents.length < 1 ? <>first</> : <>second</>} parent of{" "}
           {`${node.first_name} ${node.second_name}`}
         </h1>
+        {/* // todo add input for relationship type */}
         <Form
           formAction={async (formData: FormData) => {
             formData.append("family_id", familyId.toString())

--- a/app/tree/components/MemberModal.tsx
+++ b/app/tree/components/MemberModal.tsx
@@ -24,7 +24,6 @@ interface Props {
   familyId: number
   node: FamilyMember
   getRelationships: (id: number) => Adjacencies
-  getRelationshipType: (id: number) => RelationshipType
   getFamilyMember: (id: number) => FamilyMember
   mode?: number
 }
@@ -248,7 +247,6 @@ function PartnerSelection({
 export function ChildMode({
   node,
   familyId,
-  getRelationshipType,
   getFamilyMember,
   getRelationships,
   onClose,
@@ -389,7 +387,6 @@ export function ParentModal({
   familyId,
   node,
   onClose,
-  getRelationshipType,
   getFamilyMember,
   getRelationships,
 }: CreateModalProps) {
@@ -464,7 +461,6 @@ export default function MemberModal({
   familyId,
   node,
   getRelationships,
-  getRelationshipType,
   getFamilyMember,
   mode = Mode.Read,
 }: Props) {
@@ -479,7 +475,6 @@ export default function MemberModal({
         setModalMode={setModalMode}
         setNode={setNode}
         getRelationships={getRelationships}
-        getRelationshipType={getRelationshipType}
         getFamilyMember={getFamilyMember}
         onClose={onClose}
       />
@@ -494,7 +489,6 @@ function Content({
   onClose,
   setModalMode,
   setNode,
-  getRelationshipType,
   getFamilyMember,
   getRelationships,
 }: Props & {
@@ -522,7 +516,6 @@ function Content({
         <ChildMode
           familyId={familyId}
           node={node}
-          getRelationshipType={getRelationshipType}
           getFamilyMember={getFamilyMember}
           onClose={onClose}
           setNode={setNode}
@@ -546,7 +539,6 @@ function Content({
           familyId={familyId}
           node={node}
           getRelationships={getRelationships}
-          getRelationshipType={getRelationshipType}
           getFamilyMember={getFamilyMember}
           setModalMode={setModalMode}
           onClose={onClose}

--- a/app/tree/components/MemberModal.tsx
+++ b/app/tree/components/MemberModal.tsx
@@ -23,7 +23,6 @@ interface Props {
   onClose: () => void
   familyId: number
   node: FamilyMember
-  edges: Relationship[]
   getRelationships: (id: number) => Adjacencies
   getRelationshipType: (id: number) => RelationshipType
   getFamilyMember: (id: number) => FamilyMember
@@ -249,7 +248,6 @@ function PartnerSelection({
 export function ChildMode({
   node,
   familyId,
-  edges,
   getRelationshipType,
   getFamilyMember,
   getRelationships,
@@ -391,7 +389,6 @@ export function ParentModal({
   familyId,
   node,
   onClose,
-  edges,
   getRelationshipType,
   getFamilyMember,
   getRelationships,
@@ -466,7 +463,6 @@ export default function MemberModal({
   onClose,
   familyId,
   node,
-  edges = [],
   getRelationships,
   getRelationshipType,
   getFamilyMember,
@@ -479,7 +475,6 @@ export default function MemberModal({
       <Content
         modalMode={modalMode}
         node={n}
-        edges={edges}
         familyId={familyId}
         setModalMode={setModalMode}
         setNode={setNode}
@@ -496,7 +491,6 @@ function Content({
   familyId,
   modalMode,
   node,
-  edges,
   onClose,
   setModalMode,
   setNode,
@@ -528,7 +522,6 @@ function Content({
         <ChildMode
           familyId={familyId}
           node={node}
-          edges={edges}
           getRelationshipType={getRelationshipType}
           getFamilyMember={getFamilyMember}
           onClose={onClose}
@@ -552,7 +545,6 @@ function Content({
         <ParentModal
           familyId={familyId}
           node={node}
-          edges={edges}
           getRelationships={getRelationships}
           getRelationshipType={getRelationshipType}
           getFamilyMember={getFamilyMember}

--- a/app/tree/components/MemberModal.tsx
+++ b/app/tree/components/MemberModal.tsx
@@ -17,12 +17,14 @@ import {
 import * as React from "react"
 import styles from "./MemberModal.module.css"
 import ModalWrapper from "./ModalWrapper"
+import { Adjacencies } from "../utils/utils"
 
 interface Props {
   onClose: () => void
   familyId: number
   node: FamilyMember
   edges: Relationship[]
+  getRelationships: (id: number) => Adjacencies
   getRelationshipType: (id: number) => RelationshipType
   getFamilyMember: (id: number) => FamilyMember
   mode?: number
@@ -250,21 +252,14 @@ export function ChildMode({
   edges,
   getRelationshipType,
   getFamilyMember,
+  getRelationships,
   onClose,
   setModalMode,
   setNode,
 }: CreateModalProps) {
   const tmp: FamilyMember[] = []
-  edges.forEach((edge) => {
-    if (
-      edge.from === node.id &&
-      getRelationshipType(edge.relationship_type).type === "partner"
-    ) {
-      const partner = getFamilyMember(edge.to)
-      if (partner) {
-        tmp.push(partner)
-      }
-    }
+  getRelationships(node.id).partners.forEach((p) => {
+    tmp.push(getFamilyMember(p))
   })
   const [partners, setPartners] = React.useState(tmp)
 
@@ -353,7 +348,7 @@ export function PartnerModal({
   setModalMode,
 }: Omit<
   CreateModalProps,
-  "edges" | "getRelationshipType" | "getFamilyMember"
+  "edges" | "getRelationshipType" | "getFamilyMember" | "getRelationships"
 >) {
   return (
     <div>
@@ -399,20 +394,10 @@ export function ParentModal({
   edges,
   getRelationshipType,
   getFamilyMember,
+  getRelationships,
 }: CreateModalProps) {
   const tmp: FamilyMember[] = []
-  edges.forEach((e) => {
-    if (
-      e.to === node.id &&
-      getRelationshipType(e.relationship_type).type === "parent"
-    ) {
-      const parent = getFamilyMember(e.from)
-      if (parent) {
-        tmp.push(parent)
-      }
-    }
-  })
-
+  getRelationships(node.id).parents.forEach((p) => tmp.push(getFamilyMember(p)))
   const [parents, setParents] = React.useState<FamilyMember[]>(tmp)
   if (parents.length < 2) {
     return (
@@ -482,6 +467,7 @@ export default function MemberModal({
   familyId,
   node,
   edges = [],
+  getRelationships,
   getRelationshipType,
   getFamilyMember,
   mode = Mode.Read,
@@ -497,6 +483,7 @@ export default function MemberModal({
         familyId={familyId}
         setModalMode={setModalMode}
         setNode={setNode}
+        getRelationships={getRelationships}
         getRelationshipType={getRelationshipType}
         getFamilyMember={getFamilyMember}
         onClose={onClose}
@@ -515,6 +502,7 @@ function Content({
   setNode,
   getRelationshipType,
   getFamilyMember,
+  getRelationships,
 }: Props & {
   modalMode: number
   setModalMode: (mode: number) => void
@@ -546,6 +534,7 @@ function Content({
           onClose={onClose}
           setNode={setNode}
           setModalMode={setModalMode}
+          getRelationships={getRelationships}
         />
       )
     case Mode.Create.Partner:
@@ -564,6 +553,7 @@ function Content({
           familyId={familyId}
           node={node}
           edges={edges}
+          getRelationships={getRelationships}
           getRelationshipType={getRelationshipType}
           getFamilyMember={getFamilyMember}
           setModalMode={setModalMode}

--- a/app/tree/components/MemberModal.tsx
+++ b/app/tree/components/MemberModal.tsx
@@ -8,7 +8,12 @@ import {
   upsertPartnerRelationships,
 } from "@/app/actions"
 import RelationshipIds from "@/app/tree/components/RelationshipIds"
-import { FamilyMember, Relationship, RelationshipType, RelationshipUpsert } from "@/common.types"
+import {
+  FamilyMember,
+  Relationship,
+  RelationshipType,
+  RelationshipUpsert,
+} from "@/common.types"
 import * as React from "react"
 import styles from "./MemberModal.module.css"
 import ModalWrapper from "./ModalWrapper"
@@ -18,7 +23,7 @@ interface Props {
   familyId: number
   node: FamilyMember
   edges: Relationship[]
-  getRelationship: (id: number) => RelationshipType
+  getRelationshipType: (id: number) => RelationshipType
   getFamilyMember: (id: number) => FamilyMember
   mode?: number
 }
@@ -243,7 +248,7 @@ export function ChildMode({
   node,
   familyId,
   edges,
-  getRelationship,
+  getRelationshipType,
   getFamilyMember,
   onClose,
   setModalMode,
@@ -253,7 +258,7 @@ export function ChildMode({
   edges.forEach((edge) => {
     if (
       edge.from === node.id &&
-      getRelationship(edge.relationship_type).type === "partner"
+      getRelationshipType(edge.relationship_type).type === "partner"
     ) {
       const partner = getFamilyMember(edge.to)
       if (partner) {
@@ -346,7 +351,10 @@ export function PartnerModal({
   setNode,
   onClose,
   setModalMode,
-}: Omit<CreateModalProps, "edges" | "getRelationship" | "getFamilyMember">) {
+}: Omit<
+  CreateModalProps,
+  "edges" | "getRelationshipType" | "getFamilyMember"
+>) {
   return (
     <div>
       <h1>
@@ -374,12 +382,8 @@ export function PartnerModal({
           <label htmlFor="relationship-select">Relationship type: </label>
           <select name="relationship" id="relationship-select">
             <option value={RelationshipIds.Partner.Married}>Married</option>
-            <option value={RelationshipIds.Partner.Unmarried}>
-              Unmarried
-            </option>
-            <option value={RelationshipIds.Partner.Separated}>
-              Seperated
-            </option>
+            <option value={RelationshipIds.Partner.Unmarried}>Unmarried</option>
+            <option value={RelationshipIds.Partner.Separated}>Seperated</option>
           </select>
         </div>
         <button onClick={onClose}>Cancel</button>
@@ -393,14 +397,14 @@ export function ParentModal({
   node,
   onClose,
   edges,
-  getRelationship,
+  getRelationshipType,
   getFamilyMember,
 }: CreateModalProps) {
   const tmp: FamilyMember[] = []
   edges.forEach((e) => {
     if (
       e.to === node.id &&
-      getRelationship(e.relationship_type).type === "parent"
+      getRelationshipType(e.relationship_type).type === "parent"
     ) {
       const parent = getFamilyMember(e.from)
       if (parent) {
@@ -426,21 +430,20 @@ export function ParentModal({
               formData.delete("death_date")
             }
             const parent = await upsertNode(formData)
-            const relationships: RelationshipUpsert[] =
-              [
-                {
-                  family_id: familyId,
-                  from: node.id,
-                  to: parent.id,
-                  relationship_type: RelationshipIds.Child.Biological,
-                },
-                {
-                  family_id: familyId,
-                  from: parent.id,
-                  to: node.id,
-                  relationship_type: RelationshipIds.Parent.Biological,
-                },
-              ]
+            const relationships: RelationshipUpsert[] = [
+              {
+                family_id: familyId,
+                from: node.id,
+                to: parent.id,
+                relationship_type: RelationshipIds.Child.Biological,
+              },
+              {
+                family_id: familyId,
+                from: parent.id,
+                to: node.id,
+                relationship_type: RelationshipIds.Parent.Biological,
+              },
+            ]
             await upsertEdges(relationships)
             setParents((prev) => [...prev, parent])
           }}
@@ -463,12 +466,8 @@ export function ParentModal({
         <label htmlFor="relationship-select">{`${parents[0].first_name} ${parents[0].second_name} and ${parents[1].first_name} ${parents[1].second_name} are: `}</label>
         <select name="relationship" id="relationship-select">
           <option value={RelationshipIds.Partner.Married}>Married</option>
-          <option value={RelationshipIds.Partner.Unmarried}>
-            Unmarried
-          </option>
-          <option value={RelationshipIds.Partner.Separated}>
-            Seperated
-          </option>
+          <option value={RelationshipIds.Partner.Unmarried}>Unmarried</option>
+          <option value={RelationshipIds.Partner.Separated}>Seperated</option>
         </select>
         <div>
           <button type="submit">Submit</button>
@@ -483,7 +482,7 @@ export default function MemberModal({
   familyId,
   node,
   edges = [],
-  getRelationship,
+  getRelationshipType,
   getFamilyMember,
   mode = Mode.Read,
 }: Props) {
@@ -498,7 +497,7 @@ export default function MemberModal({
         familyId={familyId}
         setModalMode={setModalMode}
         setNode={setNode}
-        getRelationship={getRelationship}
+        getRelationshipType={getRelationshipType}
         getFamilyMember={getFamilyMember}
         onClose={onClose}
       />
@@ -514,7 +513,7 @@ function Content({
   onClose,
   setModalMode,
   setNode,
-  getRelationship,
+  getRelationshipType,
   getFamilyMember,
 }: Props & {
   modalMode: number
@@ -542,7 +541,7 @@ function Content({
           familyId={familyId}
           node={node}
           edges={edges}
-          getRelationship={getRelationship}
+          getRelationshipType={getRelationshipType}
           getFamilyMember={getFamilyMember}
           onClose={onClose}
           setNode={setNode}
@@ -565,7 +564,7 @@ function Content({
           familyId={familyId}
           node={node}
           edges={edges}
-          getRelationship={getRelationship}
+          getRelationshipType={getRelationshipType}
           getFamilyMember={getFamilyMember}
           setModalMode={setModalMode}
           onClose={onClose}

--- a/app/tree/components/MemberModal.tsx
+++ b/app/tree/components/MemberModal.tsx
@@ -10,7 +10,6 @@ import {
 import RelationshipIds from "@/app/tree/components/RelationshipIds"
 import { FamilyMember, Relationship, RelationshipType, RelationshipUpsert } from "@/common.types"
 import * as React from "react"
-import { FullItem } from "vis-data/declarations/data-interface"
 import styles from "./MemberModal.module.css"
 import ModalWrapper from "./ModalWrapper"
 
@@ -20,7 +19,7 @@ interface Props {
   node: FamilyMember
   edges: Relationship[]
   getRelationship: (id: number) => RelationshipType
-  getFamilyMember: (id: number) => FullItem<FamilyMember, "id"> | null
+  getFamilyMember: (id: number) => FamilyMember
   mode?: number
 }
 
@@ -205,9 +204,9 @@ function PartnerSelection({
   setPartners,
   onClose,
 }: {
-  parent: FullItem<FamilyMember, "id">
-  partners: FullItem<FamilyMember, "id">[]
-  setPartners: (partners: FullItem<FamilyMember, "id">[]) => void
+  parent: FamilyMember
+  partners: FamilyMember[]
+  setPartners: (partners: FamilyMember[]) => void
   onClose: () => void
 }) {
   const [current, setCurrent] = React.useState(partners[0])
@@ -250,7 +249,7 @@ export function ChildMode({
   setModalMode,
   setNode,
 }: CreateModalProps) {
-  const tmp: FullItem<FamilyMember, "id">[] = []
+  const tmp: FamilyMember[] = []
   edges.forEach((edge) => {
     if (
       edge.from === node.id &&
@@ -397,7 +396,7 @@ export function ParentModal({
   getRelationship,
   getFamilyMember,
 }: CreateModalProps) {
-  const tmp: FullItem<FamilyMember, "id">[] = []
+  const tmp: FamilyMember[] = []
   edges.forEach((e) => {
     if (
       e.to === node.id &&

--- a/app/tree/components/Members.tsx
+++ b/app/tree/components/Members.tsx
@@ -32,14 +32,15 @@ export default function Members({
   const hierarchies = setHierarchies(familyMembers, adjMap)
   const nodes = familyMembers.map((member) => {
     return {
+      id: member.id,
       label: `${member.first_name} ${member.second_name}`,
       level: hierarchies[member.id],
-      ...member,
     }
   })
   return (
     <MembersGraph
       familyId={familyId}
+      familyMembers={familyMembers}
       nodes={nodes}
       edges={relationships}
       relationshipTypes={rtMap}

--- a/app/tree/components/Members.tsx
+++ b/app/tree/components/Members.tsx
@@ -1,6 +1,7 @@
 import { FamilyMember, Relationship, RelationshipType } from "@/common.types"
 import {
   mapAdjencies,
+  mapFamilyMembers,
   mapRelationshipTypes,
   setHierarchies,
 } from "../utils/utils"
@@ -27,6 +28,7 @@ export default function Members({
     )
   }
 
+  const fmMap = mapFamilyMembers(familyMembers)
   const rtMap = mapRelationshipTypes(relationshipTypes)
   const adjMap = mapAdjencies(familyMembers, relationships, rtMap)
   const hierarchies = setHierarchies(familyMembers, adjMap)
@@ -41,7 +43,7 @@ export default function Members({
   return (
     <MembersGraph
       familyId={familyId}
-      familyMembers={familyMembers}
+      familyMembers={fmMap}
       nodes={nodes}
       edges={edges}
       relationships={relationships}

--- a/app/tree/components/Members.tsx
+++ b/app/tree/components/Members.tsx
@@ -1,5 +1,9 @@
 import { FamilyMember, Relationship, RelationshipType } from "@/common.types"
-import { setHierarchies } from "../utils/utils"
+import {
+  mapAdjencies,
+  mapRelationshipTypes,
+  setHierarchies,
+} from "../utils/utils"
 import MembersGraph from "./MembersGraph"
 
 interface Props {
@@ -23,18 +27,9 @@ export default function Members({
     )
   }
 
-  const rtMap: Record<number, RelationshipType> = {}
-  relationshipTypes.forEach((rt) => {
-    rtMap[rt.id] = rt
-  })
-  const getRelationship = (id: number) => {
-    return rtMap[id]
-  }
-  const hierarchies = setHierarchies(
-    familyMembers,
-    relationships,
-    getRelationship
-  )
+  const rtMap = mapRelationshipTypes(relationshipTypes)
+  const adjMap = mapAdjencies(familyMembers, relationships, rtMap)
+  const hierarchies = setHierarchies(familyMembers, adjMap)
   const nodes = familyMembers.map((member) => {
     return {
       label: `${member.first_name} ${member.second_name}`,

--- a/app/tree/components/Members.tsx
+++ b/app/tree/components/Members.tsx
@@ -37,12 +37,14 @@ export default function Members({
       level: hierarchies[member.id],
     }
   })
+  const edges = [...relationships]
   return (
     <MembersGraph
       familyId={familyId}
       familyMembers={familyMembers}
       nodes={nodes}
-      edges={relationships}
+      edges={edges}
+      relationships={relationships}
       relationshipTypes={rtMap}
     />
   )

--- a/app/tree/components/Members.tsx
+++ b/app/tree/components/Members.tsx
@@ -47,8 +47,6 @@ export default function Members({
       nodes={nodes}
       edges={edges}
       adjacenciesMap={adjMap}
-      relationships={relationships}
-      relationshipTypes={rtMap}
     />
   )
 }

--- a/app/tree/components/Members.tsx
+++ b/app/tree/components/Members.tsx
@@ -46,6 +46,7 @@ export default function Members({
       familyMembers={fmMap}
       nodes={nodes}
       edges={edges}
+      adjacenciesMap={adjMap}
       relationships={relationships}
       relationshipTypes={rtMap}
     />

--- a/app/tree/components/MembersGraph.tsx
+++ b/app/tree/components/MembersGraph.tsx
@@ -13,8 +13,6 @@ interface Props {
   nodes: Node[]
   edges: Edge[]
   adjacenciesMap: Record<number, Adjacencies>
-  relationships: Relationship[]
-  relationshipTypes: Record<number, RelationshipType>
 }
 
 export function MembersGraph({
@@ -22,8 +20,6 @@ export function MembersGraph({
   nodes,
   edges,
   familyId,
-  relationships,
-  relationshipTypes,
   familyMembers,
 }: Props) {
   const getRelationships = (id: number) => {

--- a/app/tree/components/MembersGraph.tsx
+++ b/app/tree/components/MembersGraph.tsx
@@ -29,9 +29,6 @@ export function MembersGraph({
   const getRelationships = (id: number) => {
     return adjacenciesMap[id]
   }
-  const getRelationshipType = (id: number) => {
-    return relationshipTypes[id]
-  }
   const getFamilyMember = (id: number) => {
     return familyMembers[id]
   }
@@ -45,7 +42,6 @@ export function MembersGraph({
           familyId={familyId}
           node={selected}
           getRelationships={getRelationships}
-          getRelationshipType={getRelationshipType}
           getFamilyMember={getFamilyMember}
           onClose={() => setSelected(undefined)}
         />

--- a/app/tree/components/MembersGraph.tsx
+++ b/app/tree/components/MembersGraph.tsx
@@ -17,11 +17,6 @@ interface Props {
   relationshipTypes: Record<number, RelationshipType>
 }
 
-interface SelectedProps {
-  node: FamilyMember
-  relationships: Relationship[]
-}
-
 export function MembersGraph({
   adjacenciesMap,
   nodes,
@@ -40,9 +35,7 @@ export function MembersGraph({
   const getFamilyMember = (id: number) => {
     return familyMembers[id]
   }
-  const rSet = new DataSet(relationships)
-
-  const [selected, setSelected] = React.useState<SelectedProps | undefined>(
+  const [selected, setSelected] = React.useState<FamilyMember | undefined>(
     undefined
   )
   return (
@@ -50,8 +43,7 @@ export function MembersGraph({
       {selected && (
         <MemberModal
           familyId={familyId}
-          node={selected.node}
-          edges={selected.relationships}
+          node={selected}
           getRelationships={getRelationships}
           getRelationshipType={getRelationshipType}
           getFamilyMember={getFamilyMember}
@@ -85,11 +77,7 @@ export function MembersGraph({
         events={{
           selectNode: (event: any) => {
             const selectedNode = getFamilyMember(event.nodes[0])
-            const connectedRelationships = rSet.get(event.edges)
-            setSelected({
-              node: selectedNode,
-              relationships: connectedRelationships,
-            })
+            setSelected(selectedNode)
           },
         }}
         // ref={(network: Network) => {

--- a/app/tree/components/MembersGraph.tsx
+++ b/app/tree/components/MembersGraph.tsx
@@ -28,7 +28,7 @@ export function MembersGraph({
   relationshipTypes,
   familyMembers,
 }: Props) {
-  const getRelationship = (id: number) => {
+  const getRelationshipType = (id: number) => {
     return relationshipTypes[id]
   }
   const getFamilyMember = (id: number) => {
@@ -46,7 +46,7 @@ export function MembersGraph({
           familyId={familyId}
           node={selected.node}
           edges={selected.relationships}
-          getRelationship={getRelationship}
+          getRelationshipType={getRelationshipType}
           getFamilyMember={getFamilyMember}
           onClose={() => setSelected(undefined)}
         />

--- a/app/tree/components/MembersGraph.tsx
+++ b/app/tree/components/MembersGraph.tsx
@@ -5,12 +5,14 @@ import * as React from "react"
 import VisGraph, { Edge, Node } from "react-vis-graph-wrapper"
 import { DataSet } from "vis-data"
 import MemberModal from "./MemberModal"
+import { Adjacencies } from "../utils/utils"
 
 interface Props {
   familyId: number
   familyMembers: Record<number, FamilyMember>
   nodes: Node[]
   edges: Edge[]
+  adjacenciesMap: Record<number, Adjacencies>
   relationships: Relationship[]
   relationshipTypes: Record<number, RelationshipType>
 }
@@ -21,6 +23,7 @@ interface SelectedProps {
 }
 
 export function MembersGraph({
+  adjacenciesMap,
   nodes,
   edges,
   familyId,
@@ -28,6 +31,9 @@ export function MembersGraph({
   relationshipTypes,
   familyMembers,
 }: Props) {
+  const getRelationships = (id: number) => {
+    return adjacenciesMap[id]
+  }
   const getRelationshipType = (id: number) => {
     return relationshipTypes[id]
   }
@@ -46,6 +52,7 @@ export function MembersGraph({
           familyId={familyId}
           node={selected.node}
           edges={selected.relationships}
+          getRelationships={getRelationships}
           getRelationshipType={getRelationshipType}
           getFamilyMember={getFamilyMember}
           onClose={() => setSelected(undefined)}

--- a/app/tree/components/MembersGraph.tsx
+++ b/app/tree/components/MembersGraph.tsx
@@ -2,7 +2,7 @@
 
 import { FamilyMember, Relationship, RelationshipType } from "@/common.types"
 import * as React from "react"
-import VisGraph, { Node } from "react-vis-graph-wrapper"
+import VisGraph, { Edge, Node } from "react-vis-graph-wrapper"
 import { DataSet } from "vis-data"
 import { FullItem } from "vis-data/declarations/data-interface"
 import MemberModal from "./MemberModal"
@@ -11,7 +11,8 @@ interface Props {
   familyId: number
   familyMembers: FamilyMember[]
   nodes: Node[]
-  edges: Relationship[]
+  edges: Edge[]
+  relationships: Relationship[]
   relationshipTypes: Record<number, RelationshipType>
 }
 
@@ -24,6 +25,7 @@ export function MembersGraph({
   nodes,
   edges,
   familyId,
+  relationships,
   relationshipTypes,
   familyMembers
 }: Props) {
@@ -31,7 +33,7 @@ export function MembersGraph({
     return relationshipTypes[id]
   }
   const fmSet = new DataSet(familyMembers)
-  const edgeSet = new DataSet(edges)
+  const rSet = new DataSet(relationships)
   const getFamilyMember = (id: number) => {
     return fmSet.get(id)
   }
@@ -82,10 +84,10 @@ export function MembersGraph({
                 event.nodes[0]
               ) as unknown as FullItem<FamilyMember, "id">
               if (selectedNode) {
-                const connectedEdges = edgeSet.get(event.edges)
+                const connectedRelationships = rSet.get(event.edges)
                 setSelected({
                   node: selectedNode,
-                  relationships: connectedEdges,
+                  relationships: connectedRelationships,
                 })
               }
             }

--- a/app/tree/components/MembersGraph.tsx
+++ b/app/tree/components/MembersGraph.tsx
@@ -2,14 +2,15 @@
 
 import { FamilyMember, Relationship, RelationshipType } from "@/common.types"
 import * as React from "react"
-import VisGraph from "react-vis-graph-wrapper"
+import VisGraph, { Node } from "react-vis-graph-wrapper"
 import { DataSet } from "vis-data"
 import { FullItem } from "vis-data/declarations/data-interface"
 import MemberModal from "./MemberModal"
 
 interface Props {
   familyId: number
-  nodes: FamilyMember[]
+  familyMembers: FamilyMember[]
+  nodes: Node[]
   edges: Relationship[]
   relationshipTypes: Record<number, RelationshipType>
 }
@@ -19,25 +20,20 @@ interface SelectedProps {
   relationships: Relationship[]
 }
 
-export type Node = FamilyMember & {
-  label: string
-  title: string
-  level: number
-}
-
 export function MembersGraph({
   nodes,
   edges,
   familyId,
   relationshipTypes,
+  familyMembers
 }: Props) {
   const getRelationship = (id: number) => {
     return relationshipTypes[id]
   }
-  const nodeSet = new DataSet(nodes)
+  const fmSet = new DataSet(familyMembers)
   const edgeSet = new DataSet(edges)
   const getFamilyMember = (id: number) => {
-    return nodeSet.get(id)
+    return fmSet.get(id)
   }
 
   const [selected, setSelected] = React.useState<SelectedProps | undefined>(
@@ -82,9 +78,9 @@ export function MembersGraph({
         events={{
           selectNode: (event: any) => {
             if (event.nodes.length === 1) {
-              const selectedNode = nodeSet.get(
+              const selectedNode = fmSet.get(
                 event.nodes[0]
-              ) as unknown as FullItem<Node, "id">
+              ) as unknown as FullItem<FamilyMember, "id">
               if (selectedNode) {
                 const connectedEdges = edgeSet.get(event.edges)
                 setSelected({

--- a/app/tree/components/MembersGraph.tsx
+++ b/app/tree/components/MembersGraph.tsx
@@ -4,12 +4,11 @@ import { FamilyMember, Relationship, RelationshipType } from "@/common.types"
 import * as React from "react"
 import VisGraph, { Edge, Node } from "react-vis-graph-wrapper"
 import { DataSet } from "vis-data"
-import { FullItem } from "vis-data/declarations/data-interface"
 import MemberModal from "./MemberModal"
 
 interface Props {
   familyId: number
-  familyMembers: FamilyMember[]
+  familyMembers: Record<number, FamilyMember>
   nodes: Node[]
   edges: Edge[]
   relationships: Relationship[]
@@ -27,16 +26,15 @@ export function MembersGraph({
   familyId,
   relationships,
   relationshipTypes,
-  familyMembers
+  familyMembers,
 }: Props) {
   const getRelationship = (id: number) => {
     return relationshipTypes[id]
   }
-  const fmSet = new DataSet(familyMembers)
-  const rSet = new DataSet(relationships)
   const getFamilyMember = (id: number) => {
-    return fmSet.get(id)
+    return familyMembers[id]
   }
+  const rSet = new DataSet(relationships)
 
   const [selected, setSelected] = React.useState<SelectedProps | undefined>(
     undefined
@@ -79,18 +77,12 @@ export function MembersGraph({
         }}
         events={{
           selectNode: (event: any) => {
-            if (event.nodes.length === 1) {
-              const selectedNode = fmSet.get(
-                event.nodes[0]
-              ) as unknown as FullItem<FamilyMember, "id">
-              if (selectedNode) {
-                const connectedRelationships = rSet.get(event.edges)
-                setSelected({
-                  node: selectedNode,
-                  relationships: connectedRelationships,
-                })
-              }
-            }
+            const selectedNode = getFamilyMember(event.nodes[0])
+            const connectedRelationships = rSet.get(event.edges)
+            setSelected({
+              node: selectedNode,
+              relationships: connectedRelationships,
+            })
           },
         }}
         // ref={(network: Network) => {

--- a/app/tree/utils/utils.test.ts
+++ b/app/tree/utils/utils.test.ts
@@ -20,19 +20,6 @@ function createAdjaciencies(props: {
   return adjencies
 }
 
-function getRelationship(id: number) {
-  const rtMap: Record<number, RelationshipType> = {
-    1: { id: 1, type: "partner", subtype: "married" },
-    2: { id: 2, type: "partner", subtype: "unmarried" },
-    3: { id: 3, type: "child", subtype: "biological" },
-    4: { id: 4, type: "child", subtype: "adopted" },
-    5: { id: 5, type: "partner", subtype: "separated" },
-    6: { id: 6, type: "parent", subtype: "biological" },
-    7: { id: 7, type: "parent", subtype: "adopted" },
-  }
-  return rtMap[id]
-}
-
 describe("actions add level", () => {
   test("should return zero for standalone line", () => {
     const adjMap: Record<number, Adjacencies> = { 1: createAdjaciencies({}) }

--- a/app/tree/utils/utils.test.ts
+++ b/app/tree/utils/utils.test.ts
@@ -2,23 +2,7 @@ import { RelationshipType } from "@/common.types"
 import { describe } from "node:test"
 import { expect, test } from "vitest"
 import { createMembers } from "../../../stories/util"
-import { Adjacencies, setHierarchies } from "./utils"
-
-function createAdjaciencies(props: {
-  parents?: number[]
-  children?: number[]
-  partners?: number[]
-}) {
-  const adjencies: Adjacencies = {
-    parents: new Set(),
-    children: new Set(),
-    partners: new Set(),
-  }
-  props.children?.forEach((a) => adjencies.children.add(a))
-  props.parents?.forEach((a) => adjencies.parents.add(a))
-  props.partners?.forEach((a) => adjencies.partners.add(a))
-  return adjencies
-}
+import { Adjacencies, createAdjaciencies, setHierarchies } from "./utils"
 
 describe("actions add level", () => {
   test("should return zero for standalone line", () => {

--- a/app/tree/utils/utils.ts
+++ b/app/tree/utils/utils.ts
@@ -92,3 +92,11 @@ export function mapAdjencies(
   }
   return adjMap
 }
+
+export function mapFamilyMembers(familyMembers: FamilyMember[]) {
+  const m: Record<number, FamilyMember> = {}
+  familyMembers.forEach((fm) => {
+    m[fm.id] = fm
+  })
+  return m
+}

--- a/app/tree/utils/utils.ts
+++ b/app/tree/utils/utils.ts
@@ -73,11 +73,7 @@ export function mapAdjencies(
   }
   const adjMap: Record<number, Adjacencies> = {}
   for (let i = 0; i < familyMembers.length; i++) {
-    adjMap[familyMembers[i].id] = {
-      parents: new Set(),
-      children: new Set(),
-      partners: new Set(),
-    }
+    adjMap[familyMembers[i].id] = createAdjaciencies({})
   }
   for (let i = 0; i < relationships.length; i++) {
     const { from, to, relationship_type } = relationships[i]
@@ -99,4 +95,20 @@ export function mapFamilyMembers(familyMembers: FamilyMember[]) {
     m[fm.id] = fm
   })
   return m
+}
+
+export function createAdjaciencies(props: {
+  parents?: number[]
+  children?: number[]
+  partners?: number[]
+}) {
+  const adjencies: Adjacencies = {
+    parents: new Set(),
+    children: new Set(),
+    partners: new Set(),
+  }
+  props.children?.forEach((a) => adjencies.children.add(a))
+  props.parents?.forEach((a) => adjencies.parents.add(a))
+  props.partners?.forEach((a) => adjencies.partners.add(a))
+  return adjencies
 }

--- a/app/tree/utils/utils.ts
+++ b/app/tree/utils/utils.ts
@@ -1,6 +1,6 @@
 import { FamilyMember, Relationship, RelationshipType } from "@/common.types"
 
-interface Adjacencies {
+export interface Adjacencies {
   partners: Set<number>
   children: Set<number>
   parents: Set<number>

--- a/app/tree/utils/utils.ts
+++ b/app/tree/utils/utils.ts
@@ -1,53 +1,33 @@
 import { FamilyMember, Relationship, RelationshipType } from "@/common.types"
 
-type Hash = Record<
-  number,
-  {
-    parents: number[]
-    children: number[]
-    partners: number[]
-    level?: number
-  }
->
+interface Adjacencies {
+  partners: Set<number>
+  children: Set<number>
+  parents: Set<number>
+}
 
 export function setHierarchies(
   nodes: FamilyMember[],
-  edges: Relationship[],
-  getRelationship: (id: number) => RelationshipType
+  adjMap: Record<number, Adjacencies>
 ): Record<number, number> {
-  const hash: Hash = {}
-  for (let i = 0; i < nodes.length; i++) {
-    hash[nodes[i].id] = { parents: [], children: [], partners: [] }
-  }
-  for (let i = 0; i < edges.length; i++) {
-    const { from, to, relationship_type } = edges[i]
-    switch (getRelationship(relationship_type).type) {
-      case "parent":
-        hash[from].children.push(to)
-      case "child":
-        hash[from].parents.push(to)
-      case "partner":
-        hash[from].partners.push(to)
-    }
-  }
-
+  const hierarchies: Record<number, number> = {}
   let stack: [number, number][] = []
   function bfs(id: number, level: number) {
-    if (hash[id].level != undefined) {
+    if (hierarchies[id] !== undefined) {
       return
     }
-    hash[id].level = level
-    hash[id].children.forEach(
+    hierarchies[id] = level
+    adjMap[id].children.forEach(
       (child) =>
-        hash[child].level === undefined && stack.push([child, level + 1])
+        hierarchies[child] === undefined && stack.push([child, level + 1])
     )
-    hash[id].parents.forEach(
+    adjMap[id].parents.forEach(
       (parent) =>
-        hash[parent].level === undefined && stack.push([parent, level - 1])
+        hierarchies[parent] === undefined && stack.push([parent, level - 1])
     )
-    hash[id].partners.forEach(
+    adjMap[id].partners.forEach(
       (partner) =>
-        hash[partner].level === undefined && stack.push([partner, level])
+        hierarchies[partner] === undefined && stack.push([partner, level])
     )
   }
 
@@ -62,10 +42,9 @@ export function setHierarchies(
     }
   }
 
-  const hierarchies: Record<number, number> = {}
   for (let i = 0; i < nodes.length; i++) {
     const id = nodes[i].id
-    const level = hash[id]?.level
+    const level = hierarchies[id]
     if (level !== undefined) {
       hierarchies[id] = level
     } else {
@@ -74,4 +53,42 @@ export function setHierarchies(
   }
 
   return hierarchies
+}
+
+export function mapRelationshipTypes(rts: RelationshipType[]) {
+  const m: Record<number, RelationshipType> = {}
+  rts.forEach((r) => {
+    m[r.id] = r
+  })
+  return m
+}
+
+export function mapAdjencies(
+  familyMembers: FamilyMember[],
+  relationships: Relationship[],
+  relationshipTypes: Record<number, RelationshipType>
+) {
+  const getRelationship = (id: number) => {
+    return relationshipTypes[id]
+  }
+  const adjMap: Record<number, Adjacencies> = {}
+  for (let i = 0; i < familyMembers.length; i++) {
+    adjMap[familyMembers[i].id] = {
+      parents: new Set(),
+      children: new Set(),
+      partners: new Set(),
+    }
+  }
+  for (let i = 0; i < relationships.length; i++) {
+    const { from, to, relationship_type } = relationships[i]
+    switch (getRelationship(relationship_type).type) {
+      case "parent":
+        adjMap[from].children.add(to)
+      case "child":
+        adjMap[from].parents.add(to)
+      case "partner":
+        adjMap[from].partners.add(to)
+    }
+  }
+  return adjMap
 }

--- a/app/tree/utils/utils.ts
+++ b/app/tree/utils/utils.ts
@@ -68,24 +68,23 @@ export function mapAdjencies(
   relationships: Relationship[],
   relationshipTypes: Record<number, RelationshipType>
 ) {
-  const getRelationship = (id: number) => {
-    return relationshipTypes[id]
-  }
   const adjMap: Record<number, Adjacencies> = {}
-  for (let i = 0; i < familyMembers.length; i++) {
-    adjMap[familyMembers[i].id] = createAdjaciencies({})
-  }
-  for (let i = 0; i < relationships.length; i++) {
-    const { from, to, relationship_type } = relationships[i]
-    switch (getRelationship(relationship_type).type) {
+  familyMembers.forEach((fm) => {
+    adjMap[fm.id] = createAdjaciencies({})
+  })
+  relationships.forEach(({ from, to, relationship_type }) => {
+    switch (relationshipTypes[relationship_type].type) {
       case "parent":
         adjMap[from].children.add(to)
+        break
       case "child":
         adjMap[from].parents.add(to)
+        break
       case "partner":
         adjMap[from].partners.add(to)
+        break
     }
-  }
+  })
   return adjMap
 }
 
@@ -108,7 +107,7 @@ export function createAdjaciencies(props: {
     partners: new Set(),
   }
   props.children?.forEach((a) => adjencies.children.add(a))
-  props.parents?.forEach((a) => adjencies.parents.add(a))
-  props.partners?.forEach((a) => adjencies.partners.add(a))
+  props.parents?.forEach((b) => adjencies.parents.add(b))
+  props.partners?.forEach((c) => adjencies.partners.add(c))
   return adjencies
 }

--- a/stories/modal/ChildModal.stories.tsx
+++ b/stories/modal/ChildModal.stories.tsx
@@ -2,7 +2,7 @@ import MemberModal, { ChildMode } from "@/app/tree/components/MemberModal"
 import ModalWrapper from "@/app/tree/components/ModalWrapper"
 import RelationshipIds from "@/app/tree/components/RelationshipIds"
 import { Meta, StoryObj } from "@storybook/react"
-import { createMembers, fakeGetRelationship } from "../util"
+import { createMembers, fakeGetRelationshipType } from "../util"
 
 const meta: Meta<typeof MemberModal> = {
   component: MemberModal,
@@ -44,7 +44,7 @@ export const CreateChildWithTwoParents: Story = {
             node={members[0]}
             edges={edges}
             getFamilyMember={getFamilyMember}
-            getRelationship={fakeGetRelationship}
+            getRelationshipType={fakeGetRelationshipType}
             onClose={() => {}}
             familyId={1}
             setModalMode={() => {}}
@@ -104,7 +104,7 @@ export const CreateChildWithMultiplePossibleParents: Story = {
             node={members[0]}
             edges={edges}
             getFamilyMember={getFamilyMember}
-            getRelationship={fakeGetRelationship}
+            getRelationshipType={fakeGetRelationshipType}
             onClose={() => {}}
             familyId={1}
             setModalMode={() => {}}
@@ -132,7 +132,7 @@ export const CreateChildWithOneParent: Story = {
             node={members[0]}
             edges={[]}
             getFamilyMember={getFamilyMember}
-            getRelationship={fakeGetRelationship}
+            getRelationshipType={fakeGetRelationshipType}
             onClose={() => {}}
             familyId={1}
             setModalMode={() => {}}

--- a/stories/modal/ChildModal.stories.tsx
+++ b/stories/modal/ChildModal.stories.tsx
@@ -3,6 +3,7 @@ import ModalWrapper from "@/app/tree/components/ModalWrapper"
 import RelationshipIds from "@/app/tree/components/RelationshipIds"
 import { Meta, StoryObj } from "@storybook/react"
 import { createMembers } from "../util"
+import { Adjacencies, createAdjaciencies } from "@/app/tree/utils/utils"
 
 const meta: Meta<typeof MemberModal> = {
   component: MemberModal,
@@ -20,29 +21,20 @@ export const CreateChildWithTwoParents: Story = {
     const getFamilyMember = (id: number) => {
       return members[id - 1]
     }
-    const edges = [
-      {
-        id: 1,
-        family_id: 1,
-        from: 1,
-        to: 2,
-        relationship_type: RelationshipIds.Partner.Married,
-      },
-      {
-        id: 2,
-        family_id: 1,
-        from: 2,
-        to: 1,
-        relationship_type: RelationshipIds.Partner.Married,
-      },
-    ]
+    const adjMap: Record<number, Adjacencies> = {
+      1: createAdjaciencies({ partners: [2] }),
+      2: createAdjaciencies({ partners: [1] }),
+    }
+    const getRelationships = (id: number) => {
+      return adjMap[id]
+    }
 
     return (
       <div id="modal-root">
         <ModalWrapper>
           <ChildMode
             node={members[0]}
-            edges={edges}
+            getRelationships={getRelationships}
             getFamilyMember={getFamilyMember}
             onClose={() => {}}
             familyId={1}
@@ -65,62 +57,12 @@ export const CreateChildWithMultiplePossibleParents: Story = {
     const getFamilyMember = (id: number) => {
       return members[id - 1]
     }
-    const edges = [
-      {
-        id: 1,
-        family_id: 1,
-        from: 1,
-        to: 2,
-        relationship_type: RelationshipIds.Partner.Married,
-      },
-      {
-        id: 2,
-        family_id: 1,
-        from: 2,
-        to: 1,
-        relationship_type: RelationshipIds.Partner.Married,
-      },
-      {
-        id: 1,
-        family_id: 1,
-        from: 1,
-        to: 3,
-        relationship_type: RelationshipIds.Partner.Separated,
-      },
-      {
-        id: 1,
-        family_id: 1,
-        from: 3,
-        to: 1,
-        relationship_type: RelationshipIds.Partner.Separated,
-      },
-    ]
-
-    return (
-      <div id="modal-root">
-        <ModalWrapper>
-          <ChildMode
-            node={members[0]}
-            edges={edges}
-            getFamilyMember={getFamilyMember}
-            onClose={() => {}}
-            familyId={1}
-            setModalMode={() => {}}
-            setNode={() => {}}
-          />
-        </ModalWrapper>
-      </div>
-    )
-  },
-}
-
-export const CreateChildWithOneParent: Story = {
-  render: () => {
-    const members = createMembers([
-      { first_name: "Parent", second_name: "One" },
-    ])
-    const getFamilyMember = (id: number) => {
-      return members[id - 1]
+    const adjMap: Record<number, Adjacencies> = {
+      1: createAdjaciencies({ partners: [2, 3] }),
+      2: createAdjaciencies({ partners: [1] }),
+    }
+    const getRelationships = (id: number) => {
+      return adjMap[id]
     }
 
     return (
@@ -128,7 +70,7 @@ export const CreateChildWithOneParent: Story = {
         <ModalWrapper>
           <ChildMode
             node={members[0]}
-            edges={[]}
+            getRelationships={getRelationships}
             getFamilyMember={getFamilyMember}
             onClose={() => {}}
             familyId={1}

--- a/stories/modal/ChildModal.stories.tsx
+++ b/stories/modal/ChildModal.stories.tsx
@@ -2,7 +2,7 @@ import MemberModal, { ChildMode } from "@/app/tree/components/MemberModal"
 import ModalWrapper from "@/app/tree/components/ModalWrapper"
 import RelationshipIds from "@/app/tree/components/RelationshipIds"
 import { Meta, StoryObj } from "@storybook/react"
-import { createMembers, fakeGetRelationshipType } from "../util"
+import { createMembers } from "../util"
 
 const meta: Meta<typeof MemberModal> = {
   component: MemberModal,
@@ -44,7 +44,6 @@ export const CreateChildWithTwoParents: Story = {
             node={members[0]}
             edges={edges}
             getFamilyMember={getFamilyMember}
-            getRelationshipType={fakeGetRelationshipType}
             onClose={() => {}}
             familyId={1}
             setModalMode={() => {}}
@@ -104,7 +103,6 @@ export const CreateChildWithMultiplePossibleParents: Story = {
             node={members[0]}
             edges={edges}
             getFamilyMember={getFamilyMember}
-            getRelationshipType={fakeGetRelationshipType}
             onClose={() => {}}
             familyId={1}
             setModalMode={() => {}}
@@ -132,7 +130,6 @@ export const CreateChildWithOneParent: Story = {
             node={members[0]}
             edges={[]}
             getFamilyMember={getFamilyMember}
-            getRelationshipType={fakeGetRelationshipType}
             onClose={() => {}}
             familyId={1}
             setModalMode={() => {}}

--- a/stories/modal/ParentModal.stories.tsx
+++ b/stories/modal/ParentModal.stories.tsx
@@ -2,7 +2,7 @@ import MemberModal, { ParentModal } from "@/app/tree/components/MemberModal"
 import ModalWrapper from "@/app/tree/components/ModalWrapper"
 import RelationshipIds from "@/app/tree/components/RelationshipIds"
 import { Meta, StoryObj } from "@storybook/react"
-import { createMembers, fakeGetRelationshipType } from "../util"
+import { createMembers } from "../util"
 
 const meta: Meta<typeof MemberModal> = {
   component: MemberModal,
@@ -31,7 +31,6 @@ export const CreateParentFirstScreen: Story = {
             node={nodes[0]}
             edges={[]}
             getFamilyMember={getFamilyMember}
-            getRelationshipType={fakeGetRelationshipType}
             onClose={() => {}}
             familyId={1}
             setModalMode={() => {}}
@@ -81,7 +80,6 @@ export const CreateParentSecondScreen: Story = {
               },
             ]}
             getFamilyMember={getFamilyMember}
-            getRelationshipType={fakeGetRelationshipType}
             onClose={() => {}}
             familyId={1}
             setModalMode={() => {}}
@@ -145,7 +143,6 @@ export const CreateParentThirdScreen: Story = {
               },
             ]}
             getFamilyMember={getFamilyMember}
-            getRelationshipType={fakeGetRelationshipType}
             onClose={() => {}}
             familyId={1}
             setModalMode={() => {}}

--- a/stories/modal/ParentModal.stories.tsx
+++ b/stories/modal/ParentModal.stories.tsx
@@ -3,6 +3,7 @@ import ModalWrapper from "@/app/tree/components/ModalWrapper"
 import RelationshipIds from "@/app/tree/components/RelationshipIds"
 import { Meta, StoryObj } from "@storybook/react"
 import { createMembers } from "../util"
+import { Adjacencies, createAdjaciencies } from "@/app/tree/utils/utils"
 
 const meta: Meta<typeof MemberModal> = {
   component: MemberModal,
@@ -13,23 +14,26 @@ type Story = StoryObj<typeof MemberModal>
 
 export const CreateParentFirstScreen: Story = {
   render: () => {
-    const nodes = createMembers([
-      { first_name: "Child", second_name: "O'Parent" },
-    ])
     const members = createMembers([
+      { first_name: "Child", second_name: "O'Parent" },
+
       { first_name: "Parent", second_name: "One" },
       { first_name: "Parent", second_name: "Two" },
     ])
     const getFamilyMember = (id: number) => {
       return members[id - 1]
     }
+    const adjMap: Record<number, Adjacencies> = { 1: createAdjaciencies({}) }
+    const getRelationships = (id: number) => {
+      return adjMap[id]
+    }
 
     return (
       <div id="modal-root">
         <ModalWrapper>
           <ParentModal
-            node={nodes[0]}
-            edges={[]}
+            node={members[0]}
+            getRelationships={getRelationships}
             getFamilyMember={getFamilyMember}
             onClose={() => {}}
             familyId={1}
@@ -44,11 +48,7 @@ export const CreateParentFirstScreen: Story = {
 
 export const CreateParentSecondScreen: Story = {
   render: () => {
-    const nodes = createMembers([
-      { first_name: "Child", second_name: "O'Parent" },
-    ])
     const members = createMembers([
-      // fake entry for id
       { first_name: "Child", second_name: "O'Parent" },
 
       { first_name: "Parent", second_name: "One" },
@@ -57,28 +57,20 @@ export const CreateParentSecondScreen: Story = {
     const getFamilyMember = (id: number) => {
       return members[id - 1]
     }
+    const adjMap: Record<number, Adjacencies> = {
+      1: createAdjaciencies({ parents: [2] }),
+      2: createAdjaciencies({ children: [1] }),
+    }
+    const getRelationships = (id: number) => {
+      return adjMap[id]
+    }
 
     return (
       <div id="modal-root">
         <ModalWrapper>
           <ParentModal
-            node={nodes[0]}
-            edges={[
-              {
-                id: 1,
-                family_id: 1,
-                from: 1,
-                to: 2,
-                relationship_type: RelationshipIds.Child.Adopted,
-              },
-              {
-                id: 2,
-                family_id: 1,
-                from: 2,
-                to: 1,
-                relationship_type: RelationshipIds.Parent.Biological,
-              },
-            ]}
+            node={members[0]}
+            getRelationships={getRelationships}
             getFamilyMember={getFamilyMember}
             onClose={() => {}}
             familyId={1}
@@ -93,11 +85,7 @@ export const CreateParentSecondScreen: Story = {
 
 export const CreateParentThirdScreen: Story = {
   render: () => {
-    const nodes = createMembers([
-      { first_name: "Child", second_name: "O'Parent" },
-    ])
     const members = createMembers([
-      // fake entry for id
       { first_name: "Child", second_name: "O'Parent" },
 
       { first_name: "Parent", second_name: "One" },
@@ -107,41 +95,21 @@ export const CreateParentThirdScreen: Story = {
       return members[id - 1]
     }
 
+    const adjMap: Record<number, Adjacencies> = {
+      1: createAdjaciencies({ parents: [2, 3] }),
+      2: createAdjaciencies({ children: [1], partners: [3] }),
+      3: createAdjaciencies({ children: [1], partners: [2] }),
+    }
+    const getRelationships = (id: number) => {
+      return adjMap[id]
+    }
+
     return (
       <div id="modal-root">
         <ModalWrapper>
           <ParentModal
-            node={nodes[0]}
-            edges={[
-              {
-                id: 1,
-                family_id: 1,
-                from: 1,
-                to: 2,
-                relationship_type: RelationshipIds.Child.Adopted,
-              },
-              {
-                id: 2,
-                family_id: 1,
-                from: 2,
-                to: 1,
-                relationship_type: RelationshipIds.Parent.Biological,
-              },
-              {
-                id: 3,
-                family_id: 1,
-                from: 3,
-                to: 1,
-                relationship_type: RelationshipIds.Parent.Biological,
-              },
-              {
-                id: 4,
-                family_id: 1,
-                from: 1,
-                to: 3,
-                relationship_type: RelationshipIds.Child.Biological,
-              },
-            ]}
+            node={members[0]}
+            getRelationships={getRelationships}
             getFamilyMember={getFamilyMember}
             onClose={() => {}}
             familyId={1}

--- a/stories/modal/ParentModal.stories.tsx
+++ b/stories/modal/ParentModal.stories.tsx
@@ -2,7 +2,7 @@ import MemberModal, { ParentModal } from "@/app/tree/components/MemberModal"
 import ModalWrapper from "@/app/tree/components/ModalWrapper"
 import RelationshipIds from "@/app/tree/components/RelationshipIds"
 import { Meta, StoryObj } from "@storybook/react"
-import { createMembers, fakeGetRelationship } from "../util"
+import { createMembers, fakeGetRelationshipType } from "../util"
 
 const meta: Meta<typeof MemberModal> = {
   component: MemberModal,
@@ -31,7 +31,7 @@ export const CreateParentFirstScreen: Story = {
             node={nodes[0]}
             edges={[]}
             getFamilyMember={getFamilyMember}
-            getRelationship={fakeGetRelationship}
+            getRelationshipType={fakeGetRelationshipType}
             onClose={() => {}}
             familyId={1}
             setModalMode={() => {}}
@@ -81,7 +81,7 @@ export const CreateParentSecondScreen: Story = {
               },
             ]}
             getFamilyMember={getFamilyMember}
-            getRelationship={fakeGetRelationship}
+            getRelationshipType={fakeGetRelationshipType}
             onClose={() => {}}
             familyId={1}
             setModalMode={() => {}}
@@ -145,7 +145,7 @@ export const CreateParentThirdScreen: Story = {
               },
             ]}
             getFamilyMember={getFamilyMember}
-            getRelationship={fakeGetRelationship}
+            getRelationshipType={fakeGetRelationshipType}
             onClose={() => {}}
             familyId={1}
             setModalMode={() => {}}

--- a/stories/util.ts
+++ b/stories/util.ts
@@ -1,4 +1,3 @@
-import { Node } from "@/app/tree/components/MembersGraph"
 import { FamilyMember, RelationshipType } from "@/common.types"
 
 interface FakeMember {
@@ -6,7 +5,7 @@ interface FakeMember {
   second_name: string
 }
 
-export const fakeMember: Node = {
+export const fakeMember: FamilyMember = {
   id: 1,
   created_at: "2024-05-01",
   family_id: 1,
@@ -19,31 +18,25 @@ export const fakeMember: Node = {
   biography:
     "Short king impresses an Austrian socialite by taking over Europe.",
   gender: "male",
-  title: "Napoleon Bonaparte",
-  label: "Napoleon Bonaparte",
-  level: 0,
 }
 
 export function createMembers(
   members: FakeMember[]
 ): FamilyMember[] {
-  let results: FamilyMember[] = []
-  for (let i = 1; i < members.length + 1; i++) {
-    results.push({
-      id: i,
+  return members.map((m, i) => {
+    return {
+      id: i + 1,
       uuid: (Math.random() + 1).toString(36).substring(7),
       family_id: i,
       birth_date: Date(),
-      first_name: members[i - 1].first_name,
-      second_name: members[i - 1].second_name,
+      first_name: m.first_name,
+      second_name: m.second_name,
       biography: null,
       created_at: Date(),
       profession: null,
       death_date: null,
-      gender: "m",
-    })
-  }
-  return results
+      gender: "m",    }
+  })
 }
 
 export function fakeGetRelationship(id: number) {

--- a/stories/util.ts
+++ b/stories/util.ts
@@ -37,16 +37,3 @@ export function createMembers(members: FakeMember[]): FamilyMember[] {
     }
   })
 }
-
-export function fakeGetRelationshipType(id: number) {
-  const rtMap: Record<number, RelationshipType> = {
-    1: { id: 1, type: "partner", subtype: "married" },
-    2: { id: 2, type: "partner", subtype: "unmarried" },
-    3: { id: 3, type: "child", subtype: "biological" },
-    4: { id: 4, type: "child", subtype: "adopted" },
-    5: { id: 5, type: "partner", subtype: "separated" },
-    6: { id: 6, type: "parent", subtype: "biological" },
-    7: { id: 7, type: "parent", subtype: "adopted" },
-  }
-  return rtMap[id]
-}

--- a/stories/util.ts
+++ b/stories/util.ts
@@ -20,9 +20,7 @@ export const fakeMember: FamilyMember = {
   gender: "male",
 }
 
-export function createMembers(
-  members: FakeMember[]
-): FamilyMember[] {
+export function createMembers(members: FakeMember[]): FamilyMember[] {
   return members.map((m, i) => {
     return {
       id: i + 1,
@@ -35,11 +33,12 @@ export function createMembers(
       created_at: Date(),
       profession: null,
       death_date: null,
-      gender: "m",    }
+      gender: "m",
+    }
   })
 }
 
-export function fakeGetRelationship(id: number) {
+export function fakeGetRelationshipType(id: number) {
   const rtMap: Record<number, RelationshipType> = {
     1: { id: 1, type: "partner", subtype: "married" },
     2: { id: 2, type: "partner", subtype: "unmarried" },


### PR DESCRIPTION
In the future, the edges in the network graph will not correspond directly to the actual relationships of family members, so we should pass the original adjacencies lists to infer the actual relationships between family members.

To explain: The edges of parents to children will have an intermediate node that represents the parent relationships, and all children's edges will point to that intermediate node. So we can't rely on the edges in the network graph in the future.

This will also allow to simplify a lot of the code, so that is its own reward.